### PR TITLE
largeword.cabal: use just-built library, not versioned

### DIFF
--- a/largeword.cabal
+++ b/largeword.cabal
@@ -37,4 +37,4 @@ Test-suite tests
                  test-framework-hunit >= 0.2.6 && < 0.4,
                  QuickCheck >= 2.4.0.1,
                  HUnit >= 1.2.2.3,
-                 largeword == 1.2.3
+                 largeword


### PR DESCRIPTION
I had 1.2.3 version installed in my system and test failed,
dropped version so smart Cabal can pick inplace library.

Signed-off-by: Sergei Trofimovich <siarheit@google.com>